### PR TITLE
Changed dump-docker-metadata cmdline argument.

### DIFF
--- a/collector/kernel/cgroup_handler.cc
+++ b/collector/kernel/cgroup_handler.cc
@@ -17,8 +17,6 @@
 
 #include <nlohmann/json.hpp>
 
-#define DUMP_DOCKER_METADATA_BASE_PATH "/var/run/flowmill/dump"
-
 using json = nlohmann::json;
 
 inline std::string make_docker_query_url(std::string const &container_name)
@@ -353,9 +351,10 @@ void CgroupHandler::handle_docker_response(u64 cgroup, std::string const &respon
   std::optional<NomadMetadata> nomad_metadata;
   std::optional<K8sMetadata> k8s_metadata;
 
-  if (settings_.dump_docker_metadata) {
+  if (settings_.docker_metadata_dump_dir) {
     auto const dump_filename = fmt::format(
-        DUMP_DOCKER_METADATA_BASE_PATH "/docker-inspect.{}.{}.json",
+        "{}/docker-inspect.{}.{}.json",
+        *settings_.docker_metadata_dump_dir,
         cgroup,
         std::chrono::system_clock::now().time_since_epoch().count());
 

--- a/collector/kernel/cgroup_handler.h
+++ b/collector/kernel/cgroup_handler.h
@@ -10,6 +10,7 @@
 #include <util/logger.h>
 #include <util/lookup3_hasher.h>
 
+#include <optional>
 #include <unordered_map>
 
 static constexpr std::string_view UNIX_SOCKET_PATH = "/var/run/docker.sock";
@@ -18,7 +19,7 @@ class CgroupHandler {
 public:
   struct CgroupSettings {
     bool force_docker_metadata = false;
-    bool dump_docker_metadata = false;
+    std::optional<std::string> docker_metadata_dump_dir;
   };
 
   // When set, specifies the name of the docker label that will be used for

--- a/collector/kernel/main.cc
+++ b/collector/kernel/main.cc
@@ -280,8 +280,13 @@ int main(int argc, char *argv[])
       *parser, "userland_tcp", "Enable userland tcp processing (experimental)", {"enable-userland-tcp"});
 
   auto force_docker_metadata = parser.add_flag("force-docker-metadata", "Forces the use of docker metadata");
-  auto dump_docker_metadata = parser.add_flag("dump-docker-metadata", "Dump docker metadata for debug purposes");
   auto disable_nomad_metadata = parser.add_flag("disable-nomad-metadata", "Disables detection and use of Nomad metadata");
+
+  args::ValueFlag<std::string> docker_metadata_dump_dir(
+      *parser,
+      "docker-metadata-dump-dir",
+      "If set, dump docker metadata to this directory (for debug purposes)",
+      {"docker-metadata-dump-dir"});
 
   args::ValueFlag<std::string> bpf_dump_file(
       *parser, "bpf-dump-file", "If set, dumps the stream of eBPF messages to the file given by this flag", {"bpf-dump-file"});
@@ -525,7 +530,7 @@ int main(int argc, char *argv[])
         socket_stats_interval_sec.Get(),
         CgroupHandler::CgroupSettings{
             .force_docker_metadata = *force_docker_metadata,
-            .dump_docker_metadata = *dump_docker_metadata,
+            .docker_metadata_dump_dir = docker_metadata_dump_dir ? std::optional(docker_metadata_dump_dir.Get()) : std::nullopt,
         },
         bpf_dump_file.Get(),
         host_info,


### PR DESCRIPTION
Now it accepts a path to a directory in which the metadata is to be dumped.